### PR TITLE
fix: Upgrade Werkzeug to 3.1.7 for CVE-2024-34069

### DIFF
--- a/app/vulnerable/requirements.txt
+++ b/app/vulnerable/requirements.txt
@@ -3,4 +3,4 @@ Flask==2.1.2
 itsdangerous==1.1.0
 Jinja2==3.0.3
 MarkupSafe==3.0.2
-Werkzeug==0.16.1
+Werkzeug==3.1.7  # Fixed CVE-2024-34069 and 9 other CVEs per Concert recommendation


### PR DESCRIPTION
## 🔒 Security Fix: CVE-2024-34069

### Summary
Upgrades Werkzeug from 0.16.1 to 3.1.7 to address **CVE-2024-34069** and 9 additional security vulnerabilities identified by IBM Concert.

### 🎯 CVE Details
- **Primary CVE**: CVE-2024-34069
- **Severity**: HIGH
- **Risk Score**: 1.8
- **Package**: werkzeug
- **Current Version**: 0.16.1 (published 2020-01-27)
- **Fixed Version**: 3.1.7 (published 2026-03-24)

### 🔍 IBM Concert Recommendation
- **Action**: UPGRADE
- **Risk Type**: high_vuln
- **Recommendation ID**: 4aa9bee9-8921-4df0-a5c3-2d8c6ad2758f
- **Description**: 10 vulnerabilities reported in werkzeug 0.16.1
- **Package URL**: pkg:pypi/werkzeug@0.16.1

### 🛡️ CVEs Fixed (10 Total)
1. **CVE-2024-34069** (HIGH) - Primary target
2. CVE-2025-66221
3. CVE-2024-49766
4. CVE-2024-49767
5. CVE-2026-27199
6. CVE-2026-21860
7. CVE-2023-25577
8. CVE-2023-46136
9. CVE-2023-23934
10. CVE-2022-29361

### 📦 Changes
- Updated `app/vulnerable/requirements.txt`
- Werkzeug: `0.16.1` → `3.1.7`

### ✅ Package Health
- License: BSD-3-Clause (allowed)
- Repository: github.com/pallets/werkzeug
- Maintained: Active (30 commits, 16 issues in last 90 days)
- Overall Score: 5.53/10

### 🧪 Testing Recommendations
- Run all application tests
- Verify Flask application functionality
- Check for any breaking changes in Werkzeug 3.x
- Test all HTTP request/response handling

### 📚 References
- Concert Package ID: 77a4d95e-97cd-47c2-8314-848078dac159
- Concert Application: sample-python-app (1c87731e-75bb-44e6-bb6d-b48e6b0abb0f)

---
*This PR was created by IBM Bob DevOps Concert mode based on Concert security recommendations.*