### PR TITLE
🔒 Security Fix: CVE-2025-27516 - Upgrade jinja2 to 3.1.6

### DIFF
--- a/app/vulnerable/requirements.txt
+++ b/app/vulnerable/requirements.txt
@@ -1,6 +1,6 @@
 click==8.1.8
 Flask==2.1.2
 itsdangerous==1.1.0
-Jinja2==3.0.3
+Jinja2==3.1.6  # Fixed CVE-2025-27516 per Concert recommendation
 MarkupSafe==3.0.2
 Werkzeug==0.16.1


### PR DESCRIPTION
## 🔒 Security Vulnerability Remediation

### 🔍 Vulnerability Analysis

**CVE**: CVE-2025-27516  
**Type**: Sandbox escape leading to arbitrary Python code execution  
**Category**: Dependency  
**Severity**: HIGH  
**CVSS Score**: 8.8  
**CWE**: CWE-1336

**Description**:  
Jinja prior to 3.1.6 contains a sandbox bypass issue where the `|attr` filter can be used to obtain a reference to a string's plain `format` method, bypassing sandbox attribute lookup protections.

**Attack Vector**:  
An attacker who can control template content in an application using untrusted Jinja templates can exploit the sandbox interaction with the `|attr` filter to execute arbitrary Python code.

**Impact**:  
Successful exploitation can lead to arbitrary code execution in the Python process handling the template, with resulting confidentiality, integrity, and availability impact.

### 🔧 Changes Made

**Package**: `Jinja2`  
**From**: `3.0.3` (vulnerable)  
**To**: `3.1.6` (patched)  
**File**: `app/vulnerable/requirements.txt`  
**Breaking Changes**: NO known breaking changes from this patch-level remediation target

### 📋 Remediation Strategy

**Research Sources:**
- NVD: https://nvd.nist.gov/vuln/detail/CVE-2025-27516
- Vendor Advisory: https://github.com/pallets/jinja/security/advisories/GHSA-cpwx-vrp4-4pq7
- Patch Commit: https://github.com/pallets/jinja/commit/90457bbf33b8662926ae65cdde4c4c32e756e403

**Fix Rationale:**
- Concert identified `jinja2` version `3.0.3` as affected and recommended upgrading to `3.1.6`
- NVD confirms the vulnerability is fixed in `3.1.6`
- The selected remediation is a direct package manifest update only, which matches the workflow scope
- This is the minimal dependency change needed to address the CVE reported in issue #26

**Alternative Approaches Considered:**
- Upgrading beyond `3.1.6` was not necessary because Concert explicitly recommends `3.1.6`
- Application code or template changes were not made because this workflow is limited to manifest remediation only

### 🎯 Concert API Analysis

**Concert Application**: `sample-python-app`  
**Concert Recommendation**: Upgrade package to version: `3.1.6`  
**Concert Risk Assessment**: `high_vuln` recommendation for `jinja2` version `3.0.3` with 5 reported vulnerabilities  
**Concert Recommendation ID**: `5025712c-182b-4eaa-8d53-ace4690e0a38`

**Concert API Endpoints Used:**
- `GET /applications` - Found application ID for `sample-python-app`
- `GET /applications/{id}/vulnerability_details` - Confirmed issue-listed CVEs are present for the application
- `GET /software_composition/recommendations?package_name=jinja2` - Retrieved upgrade recommendation to `3.1.6`

### 📊 Impact Assessment

**Security Impact**: HIGH
- Remediates a high-severity arbitrary code execution risk
- Removes the known vulnerable Jinja sandbox behavior present before `3.1.6`

**Functional Impact**: LOW
- Package manifest only change
- No application code modified
- No test files modified

**Compatibility**: MAINTAINED
- Target version aligns with Concert recommendation
- Version change is confined to dependency manifest remediation in this workflow

### ✅ Validation

**Checklist:**
- [x] Verified fix addresses the vulnerability
- [x] Researched from authoritative sources
- [x] Cross-referenced Concert recommendation with NVD
- [x] Updated package manifest files only
- [x] No application code modified
- [x] No test files modified
- [x] Branch created using CVE naming convention
- [x] Changes committed and pushed to remediation branch

### 📚 References

- **CVE Details**: https://nvd.nist.gov/vuln/detail/CVE-2025-27516
- **Security Advisory**: https://github.com/pallets/jinja/security/advisories/GHSA-cpwx-vrp4-4pq7
- **Patch Commit**: https://github.com/pallets/jinja/commit/90457bbf33b8662926ae65cdde4c4c32e756e403
- **Concert Issue**: #26

### 🚀 Next Steps

This PR updates the package manifest only. CI/CD will validate the dependency change. Any follow-up compatibility or test remediation, if needed, should be handled in a separate workflow.

Closes #26