### PR TITLE
fix: upgrade flask to 2.2.5 for CVE-2023-30861

### DIFF
--- a/app/vulnerable/requirements.txt
+++ b/app/vulnerable/requirements.txt
@@ -1,5 +1,5 @@
 click==8.1.8
-Flask==2.1.2
+Flask==2.2.5
 itsdangerous==1.1.0
 Jinja2==3.0.3
 MarkupSafe==3.0.2


### PR DESCRIPTION
## Summary
- upgrade Flask in `app/vulnerable/requirements.txt` from `2.1.2` to `2.2.5`
- remediate the high-severity vulnerability tracked in issue #44
- keep the change scoped to dependency manifest updates only

## CVE Details
- CVE: `CVE-2023-30861`
- Severity: `HIGH` in the triggering GitHub issue
- Affected application in Concert: `sample-python-app` `1.0.0`
- Vulnerable package version from issue/repository: `Flask 2.1.2`
- Fixed version applied: `Flask 2.2.5`

## Concert Research
- Concert application matched: `sample-python-app`
- Concert issue context shows Flask `2.1.2` associated with CVE findings including `CVE-2023-30861`
- Concert recommendations endpoint did not return a direct Flask recommendation entry, so the fix version was validated against a public authoritative advisory

## Public Advisory Validation
NVD for `CVE-2023-30861` states:
- affected: all Flask versions before `2.2.5`, and `2.3.0` through `2.3.1`
- fixed: `2.2.5` and `2.3.2`

Applied the minimal branch-safe fix to `2.2.5`.

## Scope
- changed only dependency manifest content
- did not modify application code, tests, fixtures, or runtime configuration

Closes #44