### PR TITLE
fix: upgrade jinja2 to 3.1.6 for multiple CVEs

### DIFF
--- a/app/vulnerable/requirements.txt
+++ b/app/vulnerable/requirements.txt
@@ -1,6 +1,6 @@
 click==8.1.8
 Flask==2.1.2
 itsdangerous==1.1.0
-Jinja2==3.0.3
+Jinja2==3.1.6
 MarkupSafe==3.0.2
 Werkzeug==0.16.1


### PR DESCRIPTION
## Summary
This PR upgrades the `jinja2` package from version 3.0.3 to 3.1.6 to address 5 security vulnerabilities identified by IBM Concert.

## CVE Details

| CVE ID | Severity | CVSS Score | Risk Score |
|--------|----------|------------|------------|
| CVE-2024-22195 | MEDIUM | 6.1 | 0.7 |
| CVE-2024-34064 | MEDIUM | 5.4 | 0.6 |
| CVE-2024-56201 | HIGH | 8.8 | 1.1 |
| CVE-2024-56326 | HIGH | 7.8 | 0.9 |
| CVE-2025-27516 | HIGH | 8.8 | 0.9 |

## Concert Recommendation
**Action:** Upgrade package to version 3.1.6  
**Description:** 5 vulnerabilities are reported by package jinja2 with version 3.0.3  
**Package Status:** Back-Level  
**Latest Available Version:** 3.1.6

## Changes Made
- Updated `app/vulnerable/requirements.txt`
- Upgraded `Jinja2` from `3.0.3` to `3.1.6`

## Validation
This remediation follows Concert's package upgrade recommendation and addresses all identified CVEs in the jinja2 package.

Resolves #26