### PR TITLE
fix: upgrade flask to 2.2.5 for CVE-2023-30861

### DIFF
--- a/app/vulnerable/requirements.txt
+++ b/app/vulnerable/requirements.txt
@@ -1,5 +1,5 @@
 click==8.1.8
-Flask==2.1.2
+Flask==2.2.5
 itsdangerous==1.1.0
 Jinja2==3.0.3
 MarkupSafe==3.0.2


### PR DESCRIPTION
## Summary
- upgrades `Flask` from `2.1.2` to `2.2.5` in `app/vulnerable/requirements.txt`
- addresses `CVE-2023-30861` for the sample Python application
- limits changes to the dependency manifest only

## Issue
Resolves #44

## CVE details
- CVE: `CVE-2023-30861`
- Package: `Flask`
- Current version: `2.1.2`
- Fixed version applied: `2.2.5`
- Severity hint from issue/Concert: `HIGH`
- Concert application: `sample-python-app`

## Concert research
- Concert application ID: `1c87731e-75bb-44e6-bb6d-b48e6b0abb0f`
- Concert vulnerability details include `CVE-2023-30861` for the application
- Concert recommendations endpoint did not return a Flask-specific recommendation entry, so the package fix was selected from authoritative public advisory guidance while staying within manifest-only scope

## Public advisory validation
Authoritative public advisory review confirmed:
- Flask versions `< 2.2.5` are affected by `CVE-2023-30861`
- Flask `2.2.5` contains the fix
- Flask `2.1.2` is affected

References:
- NVD: https://nvd.nist.gov/vuln/detail/CVE-2023-30861
- Flask advisory: https://github.com/pallets/flask/security/advisories/GHSA-m2qf-hxjv-5gpq

## Scope
- no application source changes
- no test changes
- no runtime/configuration changes
