### PR TITLE
fix: upgrade werkzeug to 3.1.7 for multiple CVEs

### DIFF
--- a/app/vulnerable/requirements.txt
+++ b/app/vulnerable/requirements.txt
@@ -1,6 +1,6 @@
 click==8.1.8
 Flask==2.1.2
-itsdangerous==1.1.0
+itsdangerous==2.0.1
 Jinja2==3.0.3
 MarkupSafe==3.0.2
-Werkzeug==0.16.1
+Werkzeug==3.1.7


### PR DESCRIPTION
## Summary
Upgrades werkzeug from 0.16.1 to 3.1.7 to address 9 CVEs identified by IBM Concert.

## CVEs Addressed
This PR fixes the following vulnerabilities in the werkzeug package:

| CVE | Severity | CVSS Score | Risk Score |
|-----|----------|------------|------------|
| CVE-2023-23934 | LOW | 3.5 | 0.4 |
| CVE-2023-25577 | HIGH | 7.5 | 0.9 |
| CVE-2023-46136 | HIGH | 7.5 | 0.9 |
| CVE-2024-34069 | HIGH | 7.5 | 1.8 |
| CVE-2024-49766 | MEDIUM | 5.3 | 0.6 |
| CVE-2024-49767 | HIGH | 7.5 | 0.9 |
| CVE-2025-66221 | MEDIUM | 5.3 | 0.5 |
| CVE-2026-21860 | MEDIUM | 5.3 | 0.5 |
| CVE-2026-27199 | MEDIUM | 5.3 | 0.5 |

## Concert Recommendation
- **Recommendation ID**: 4aa9bee9-8921-4df0-a5c3-2d8c6ad2758f
- **Action**: Upgrade package
- **Recommended Version**: 3.1.7
- **Risk Type**: high_vuln
- **Package Source**: pkg:pypi/werkzeug@0.16.1

## Changes Made
### Package Upgrades
- **werkzeug**: 0.16.1 → 3.1.7
- **itsdangerous**: 1.1.0 → 2.0.1 (transitive dependency upgrade)

### Transitive Dependency Analysis
The werkzeug upgrade required updating itsdangerous to resolve a dependency conflict:
- Flask 2.1.2 requires itsdangerous>=2.0
- Original requirements.txt specified itsdangerous==1.1.0
- Upgraded to itsdangerous==2.0.1 to satisfy Flask's dependency requirement

### Verification
✅ All dependencies verified with `pip install -r requirements.txt --dry-run`
```
Would install Flask-2.1.2 Jinja2-3.0.3 MarkupSafe-3.0.2 Werkzeug-3.1.7 click-8.1.8 itsdangerous-2.0.1
```

## Files Modified
- `app/vulnerable/requirements.txt`

## Testing Required
- [ ] Unit tests pass with upgraded dependencies
- [ ] Application functionality verified with werkzeug 3.1.7
- [ ] No breaking changes in werkzeug API usage

## References
- Resolves #27
- Concert Application: sample-python-app (ID: 1c87731e-75bb-44e6-bb6d-b48e6b0abb0f)
- Package ID: 77a4d95e-97cd-47c2-8314-848078dac159